### PR TITLE
Remove deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   },
   "dependencies": {
     "ssh-exec": "^1.3.0",
-    "smartfritz-promise": "^0.6.1"
+    "fritzapi": "^0.8.1"
   }
 }


### PR DESCRIPTION
https://github.com/andig/smartfritz is deprecated and replaced by https://github.com/andig/fritzapi